### PR TITLE
Update to work with newer versions of kakoune

### DIFF
--- a/shellcheck.kak
+++ b/shellcheck.kak
@@ -33,7 +33,7 @@ define-command -hidden -override -docstring "enable shellcheck in the current wi
         fi
         echo "shellcheck $flags"
     }
-    lint-enable
+    lint
     hook -group shellcheck window BufWritePre .* %{
         lint
     }
@@ -54,7 +54,7 @@ define-command -override -docstring "enable shellcheck in the current window" sh
     }
 }
 define-command -override -docstring "disable shellcheck in the current window" shellcheck-disable %{
-    lint-disable
+    lint-hide-diagnostics
     remove-hooks window shellcheck
 }
 


### PR DESCRIPTION
lint-enabled is no longer a command and lint-disable was renamed to lint-hide-diagnostics as of version 2020.08.04.